### PR TITLE
DTSPO-1875 - set mavenCentral to default build repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - name: Set up JDK 11

--- a/{{cookiecutter.component_id}}/build.gradle
+++ b/{{cookiecutter.component_id}}/build.gradle
@@ -155,8 +155,8 @@ dependencyManagement {
 
 repositories {
   mavenLocal()
-  jcenter()
   mavenCentral()
+  jcenter()
 }
 
 def versions = [


### PR DESCRIPTION
### Change description ###
- set mavenCentral to default build repo
- Pin ubuntu version 18.04 to fix the cookiecutter build, until we sort out the installing on the latest ubuntu workers.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
