### PR TITLE
Suppress some CVEs

### DIFF
--- a/skeleton/build.gradle
+++ b/skeleton/build.gradle
@@ -208,7 +208,6 @@ dependencies {
   implementation group: 'org.yaml', name: 'snakeyaml', version: '1.33'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLoggingVersion
-  implementation group: 'com.github.hmcts', name: 'properties-volume-spring-boot-starter', version: '0.1.1'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
   implementation group: 'io.rest-assured', name: 'rest-assured'

--- a/skeleton/config/owasp/suppressions.xml
+++ b/skeleton/config/owasp/suppressions.xml
@@ -17,7 +17,6 @@
   <suppress>
     <notes><![CDATA[
    file name: snakeyaml-1.33.jar
-   SnakeYaml's Constructor() class does not restrict types which can be instantiated during deserialization
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
     <cve>CVE-2022-3064</cve>
@@ -26,16 +25,7 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-   file name: spring-security-crypto-5.7.6.jar
-   Spring Security versions 5.3.x prior to 5.3.2, 5.2.x prior to 5.2.4, 5.1.x prior to 5.1.10, 5.0.x prior to 5.0.16 and 4.2.x prior to 4.2.16 use a fixed null initialization vector with CBC Mode in the implementation of the queryable text encryptor. A malicious user with access to the data that has been encrypted using such an encryptor may be able to derive the unencrypted values using a dictionary attack.
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
-    <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
    file name: spring-web-5.3.24.jar
-   Pivotal Spring Framework through 5.3.16 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
     <vulnerabilityName>CVE-2016-1000027</vulnerabilityName>

--- a/skeleton/config/owasp/suppressions.xml
+++ b/skeleton/config/owasp/suppressions.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2030-01-01">
-    <notes><![CDATA[
-     Suppressing as it's a false positive (see: https://pivotal.io/security/cve-2018-1258)
-   ]]></notes>
-    <gav regex="true">^org\.springframework\.security:spring-security-crypto:5.3.[0-4].RELEASE</gav>
-    <cpe>cpe:/a:pivotal_software:spring_security</cpe>
-    <cve>CVE-2018-1258</cve>
-  </suppress>
- <suppress>
+  <suppress>
     <notes><![CDATA[
         CVE is a json vulnerability for Node projects. False positive reported at https://github.com/jeremylong/DependencyCheck/issues/2794
     ]]></notes>
@@ -29,5 +21,20 @@
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
     <cve>CVE-2022-3064</cve>
     <cve>CVE-2021-4235</cve>
+    <cve>CVE-2022-1471</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-security-crypto-5.7.6.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
+    <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-web-5.3.24.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
+    <vulnerabilityName>CVE-2016-1000027</vulnerabilityName>
   </suppress>
 </suppressions>

--- a/skeleton/config/owasp/suppressions.xml
+++ b/skeleton/config/owasp/suppressions.xml
@@ -17,6 +17,7 @@
   <suppress>
     <notes><![CDATA[
    file name: snakeyaml-1.33.jar
+   SnakeYaml's Constructor() class does not restrict types which can be instantiated during deserialization
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
     <cve>CVE-2022-3064</cve>
@@ -26,6 +27,7 @@
   <suppress>
     <notes><![CDATA[
    file name: spring-security-crypto-5.7.6.jar
+   Spring Security versions 5.3.x prior to 5.3.2, 5.2.x prior to 5.2.4, 5.1.x prior to 5.1.10, 5.0.x prior to 5.0.16 and 4.2.x prior to 4.2.16 use a fixed null initialization vector with CBC Mode in the implementation of the queryable text encryptor. A malicious user with access to the data that has been encrypted using such an encryptor may be able to derive the unencrypted values using a dictionary attack.
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
     <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
@@ -33,6 +35,7 @@
   <suppress>
     <notes><![CDATA[
    file name: spring-web-5.3.24.jar
+   Pivotal Spring Framework through 5.3.16 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
     <vulnerabilityName>CVE-2016-1000027</vulnerabilityName>


### PR DESCRIPTION
No newer versions of snakeyaml available
This is the latest version of spring web without upgrading to springboot 3 which is non-trivial and being worked on
Removed the deprecated hmcts properties-volume-spring-boot-starter lib

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
