### PR TITLE
Dtspo 17422 add java 21 support

### DIFF
--- a/skeleton/.github/workflows/ci.yaml
+++ b/skeleton/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
         java-version: '17'

--- a/skeleton/acb.tpl.yml
+++ b/skeleton/acb.tpl.yml
@@ -1,7 +1,7 @@
 version: 1.0-preview-1
 steps:
   - id: pull-base-image-amd64
-    cmd: docker pull --platform linux/amd64 hmctspublic.azurecr.io/base/java:17-distroless && docker tag hmctspublic.azurecr.io/base/java:17-distroless hmctspublic.azurecr.io/base/java/linux/amd64:17-distroless
+    cmd: docker pull --platform linux/amd64 hmctspublic.azurecr.io/base/java:21-distroless && docker tag hmctspublic.azurecr.io/base/java:21-distroless hmctspublic.azurecr.io/base/java/linux/amd64:17-distroless
     when: ["-"]
     keep: true
 
@@ -16,7 +16,7 @@ steps:
     keep: true
 
   - id: pull-base-image-arm64
-    cmd: docker pull --platform linux/arm64 hmctspublic.azurecr.io/base/java:17-distroless && docker tag hmctspublic.azurecr.io/base/java:17-distroless hmctspublic.azurecr.io/base/java/linux/arm64:17-distroless
+    cmd: docker pull --platform linux/arm64 hmctspublic.azurecr.io/base/java:21-distroless && docker tag hmctspublic.azurecr.io/base/java:21-distroless hmctspublic.azurecr.io/base/java/linux/arm64:17-distroless
     when:
       - pull-base-image-amd64
     keep: true

--- a/skeleton/build.gradle
+++ b/skeleton/build.gradle
@@ -15,7 +15,7 @@ version = '0.0.1'
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(21)
   }
 }
 

--- a/skeleton/build.gradle
+++ b/skeleton/build.gradle
@@ -204,6 +204,8 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
   implementation group: 'io.rest-assured', name: 'rest-assured'
+//  CVE-2023-35116 affects versions before 2.16.0
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.16.0'
 
   testImplementation(platform('org.junit:junit-bom:5.10.2'))
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/skeleton/config/pmd/ruleset.xml
+++ b/skeleton/config/pmd/ruleset.xml
@@ -17,7 +17,6 @@
     <exclude name="MethodArgumentCouldBeFinal"/>
     <exclude name="OnlyOneReturn"/>
     <exclude name="TooManyStaticImports"/>
-    <exclude name="DefaultPackage"/>
     <exclude name="CommentDefaultAccessModifier"/>
   </rule>
   <rule ref="category/java/codestyle.xml/ClassNamingConventions">
@@ -50,6 +49,7 @@
   <rule ref="category/java/design.xml/LawOfDemeter">
     <properties>
       <property name="violationSuppressRegex" value="(.*method chain calls.*|.*object not created locally.*)"/>
+      <property name="trustRadius" value="2" />
     </properties>
   </rule>
   <rule ref="category/java/design.xml/SignatureDeclareThrowsException">
@@ -63,7 +63,6 @@
     <exclude name="UncommentedEmptyMethodBody"/>
   </rule>
   <rule ref="category/java/errorprone.xml">
-    <exclude name="BeanMembersShouldSerialize"/>
   </rule>
   <rule ref="category/java/multithreading.xml"/>
   <rule ref="category/java/performance.xml"/>

--- a/skeleton/src/functionalTest/java/uk/gov/hmcts/${{ values.product }}/${{ values.component | replace("-", "") }}/controllers/SampleFunctionalTest.java
+++ b/skeleton/src/functionalTest/java/uk/gov/hmcts/${{ values.product }}/${{ values.component | replace("-", "") }}/controllers/SampleFunctionalTest.java
@@ -33,7 +33,7 @@ class SampleFunctionalTest {
             .then()
             .extract().response();
 
-        Assertions.assertEquals(200, response.statusCode());
-        Assertions.assertTrue(response.asString().startsWith("Welcome"));
+        Assertions.assertEquals(200, response.statusCode(), "Response code was not 200.");
+        Assertions.assertTrue(response.asString().startsWith("Welcome"), "Response did not start with 'Welcome'.");
     }
 }

--- a/skeleton/src/main/java/uk/gov/hmcts/${{ values.product }}/${{ values.component | replace("-", "") }}/controllers/RootController.java
+++ b/skeleton/src/main/java/uk/gov/hmcts/${{ values.product }}/${{ values.component | replace("-", "") }}/controllers/RootController.java
@@ -20,12 +20,12 @@ public class RootController {
     @Operation(summary = "Get welcome api",
         description = "This is a welcome endpoint"
     )
-    @ApiResponses(value = {
+    @ApiResponses({
         @ApiResponse(responseCode = "200", description = "A welcome message"),
         @ApiResponse(responseCode = "404", description = "No welcome could be found")
     })
     @RequestMapping(value = "/", method = GET, produces = TEXT_PLAIN_VALUE)
-    
+
     public ResponseEntity<String> welcome() {
         return ok("Welcome to ${{ values.product }}-${{ values.component }} application");
     }

--- a/skeleton/src/smokeTest/java/uk/gov/hmcts/${{ values.product }}/${{ values.component | replace("-", "") }}/controllers/SampleSmokeTest.java
+++ b/skeleton/src/smokeTest/java/uk/gov/hmcts/${{ values.product }}/${{ values.component | replace("-", "") }}/controllers/SampleSmokeTest.java
@@ -33,7 +33,7 @@ class SampleSmokeTest {
             .then()
             .extract().response();
 
-        Assertions.assertEquals(200, response.statusCode());
-        Assertions.assertTrue(response.asString().startsWith("Welcome"));
-    } 
+        Assertions.assertEquals(200, response.statusCode(), "Response code was not 200.");
+        Assertions.assertTrue(response.asString().startsWith("Welcome"), "Response did not start with 'Welcome'.");
+    }
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17422


### Change description ###
- Updates gh action version
- Fixes pmd rule violations
- Sets minimum jackson-databind dependency version to 2.16.0 to prevent `CVE-2023-35116`
- Upgrades Java version to 21

Created a repo from this template, applied the above changes and deployed to sbox to test. Pod spun up as expected with no errors.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
